### PR TITLE
Update footer copyright

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -88,7 +88,7 @@
             <div class="container">
                 <div class="row">
                     <div class="col-lg-12">
-                        &#169; 2019 <a href="https://twitter.com/dippnerd">Aaron Dippner</a>
+                        &#169; 2019-2024 <a href="https://twitter.com/dippnerd">Aaron Dippner</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Acknowledged, this is an insane PR to just open out of the blue

But I am in the midst of writing a probs-too-long (but ~importance-ordered, prefix-readable) email to `support@justtimers.app` and was gonna include this as prose ... but now I can leave that off

/ while preemptively worrying about following up on that email, making sure you knew to look for it in case the length alone got it spam filtered or such, and with your/the app's Twitters having gone ~inactive since the Elonpocalypse, I ended up here ; and I guess that serves that purpose (preemptively)

As re the website piece of that: you might consider replacing/supplementing the Twitter links with Mastodon[^1], Bluesky[^2], or Threads ones, if so inclined. And/but if you also simply are over this concept of social media, you also might consider simply removing them.

[^1]: which I saw you had a personal account, though also have gone quiet on; `@JustTimers` might run up against fedi-politics, but there was some server/instance I came across early during the Elonpocalypse that was like (but not exactly, apparently) `apps.world` that was explicitly for this.

[^2]: which just recently un-invite-walled registration